### PR TITLE
feat: spotify hooks and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This is prototype app built in React, integrating with the Spotify typescript SD
 - ⚛️ React 18 with TypeScript
 - ⚡ Vite for fast development and building
 - 🎨 Tailwind CSS for styling
-- 🧪 Vitest + Jest for testing
+- 🧪 Vitest for testing
+- 🧪 @testing-library/react for DOM testing
 - 📦 pnpm for package management
+- 🐙 GitHub Workflow for lint, test, build automation
 
 This project was bootstrapped using the [create-react-app-vite](https://github.com/laststance/create-react-app-vite) template, providing a modern development experience with hot module replacement and optimized builds.
 
@@ -41,7 +43,9 @@ pnpm serve           # launch server for production bundle in local
 pnpm remove:tailwind # remove TailwindCSS
 ```
 
-# Notes:
+# Learning Notes:
 
-The act extension for the GH command line tool is helpful testing workflows locally prior to PRs. Requires Docker.
-https://nektosact.com/introduction.html
+- The act extension for the GH command line tool is helpful testing workflows locally prior to PRs. Requires Docker.
+  https://nektosact.com/introduction.html
+
+- Vitest provides nice mocking for testing page components

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,11 +3,15 @@ import { vi } from 'vitest'
 
 import App from './App'
 
-// Mock all the page components to avoid external dependencies
+// Mock page components
 vi.mock('./pages/Index', () => ({
   default: () => (
     <div data-testid="index-page">My Spotify Listening Habits</div>
   ),
+}))
+
+vi.mock('./pages/Dashboard', () => ({
+  default: () => <div data-testid="dashboard-page">Dashboard Page</div>,
 }))
 
 vi.mock('./pages/Notfound', () => ({

--- a/src/global.css
+++ b/src/global.css
@@ -1,4 +1,4 @@
-@import "tailwindcss/preflight";
+@import 'tailwindcss/preflight';
 @tailwind utilities;
 
 @layer base {
@@ -17,8 +17,9 @@
 
   body {
     font-family:
-      -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-      'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+      -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+      sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }

--- a/src/hooks/useSpotify.test.ts
+++ b/src/hooks/useSpotify.test.ts
@@ -1,0 +1,118 @@
+import type { SpotifyApi } from '@spotify/web-api-ts-sdk'
+import { renderHook, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import { useSpotify, useCurrentUser } from './useSpotify'
+
+// Mock the Spotify SDK
+const mockSpotifyApi = {
+  authenticate: vi.fn(),
+  currentUser: {
+    profile: vi.fn(),
+  },
+}
+
+const mockAuth = vi.fn()
+
+vi.mock('@spotify/web-api-ts-sdk', () => ({
+  AuthorizationCodeWithPKCEStrategy: vi.fn(() => mockAuth),
+  SpotifyApi: vi.fn(() => mockSpotifyApi),
+  Scopes: {
+    userDetails: ['user-read-private'],
+    userFollowRead: ['user-follow-read'],
+    playlistRead: ['playlist-read-private'],
+    userLibrary: ['user-library-read'],
+  },
+}))
+
+// Mock environment variables
+vi.mock('import.meta', () => ({
+  env: {
+    VITE_SPOTIFY_CLIENT_ID: 'test-client-id',
+    VITE_SPOTIFY_CLIENT_REDIRECT_URL: 'http://localhost:3000',
+  },
+}))
+
+describe('useSpotify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns null sdk initially', () => {
+    const { result } = renderHook(() => useSpotify())
+    expect(result.current.sdk).toBeNull()
+  })
+
+  test('sets sdk when authentication succeeds', async () => {
+    mockSpotifyApi.authenticate.mockResolvedValue({ authenticated: true })
+
+    const { result } = renderHook(() => useSpotify())
+
+    await waitFor(() => {
+      expect(result.current.sdk).toBe(mockSpotifyApi)
+    })
+  })
+
+  test('keeps sdk null when authentication fails', async () => {
+    mockSpotifyApi.authenticate.mockRejectedValue(new Error('Auth failed'))
+
+    const { result } = renderHook(() => useSpotify())
+
+    await waitFor(() => {
+      expect(result.current.sdk).toBeNull()
+    })
+  })
+})
+
+describe('useCurrentUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns initial state when no sdk provided', () => {
+    const { result } = renderHook(() => useCurrentUser(null))
+
+    expect(result.current.user).toBeNull()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  test('fetches user profile successfully', async () => {
+    const mockUser = {
+      display_name: 'Test User',
+      email: 'test@example.com',
+      country: 'US',
+      followers: { total: 100 },
+      images: [{ url: 'http://example.com/image.jpg' }],
+    }
+
+    mockSpotifyApi.currentUser.profile.mockResolvedValue(mockUser)
+
+    const { result } = renderHook(() =>
+      useCurrentUser(mockSpotifyApi as unknown as SpotifyApi),
+    )
+
+    // Should start loading
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.user).toEqual(mockUser)
+      expect(result.current.loading).toBe(false)
+      expect(result.current.error).toBeNull()
+    })
+  })
+
+  test('handles error when fetching user profile fails', async () => {
+    mockSpotifyApi.currentUser.profile.mockRejectedValue(new Error('API Error'))
+
+    const { result } = renderHook(() =>
+      useCurrentUser(mockSpotifyApi as unknown as SpotifyApi),
+    )
+
+    await waitFor(() => {
+      expect(result.current.user).toBeNull()
+      expect(result.current.loading).toBe(false)
+      expect(result.current.error).toBe('API Error')
+    })
+  })
+})

--- a/src/hooks/useSpotify.ts
+++ b/src/hooks/useSpotify.ts
@@ -1,0 +1,86 @@
+import type { UserProfile } from '@spotify/web-api-ts-sdk'
+import {
+  AuthorizationCodeWithPKCEStrategy,
+  Scopes,
+  SpotifyApi,
+} from '@spotify/web-api-ts-sdk'
+import { useEffect, useState } from 'react'
+
+const SCOPES = [
+  ...Scopes.userDetails,
+  ...Scopes.userFollowRead,
+  ...Scopes.playlistRead,
+  ...Scopes.userLibrary,
+]
+
+export const useSpotify = (customScopes: string[] = SCOPES) => {
+  const [sdk, setSdk] = useState<SpotifyApi | null>(null)
+
+  useEffect(() => {
+    const initSdk = async () => {
+      try {
+        const auth = new AuthorizationCodeWithPKCEStrategy(
+          import.meta.env.VITE_SPOTIFY_CLIENT_ID,
+          import.meta.env.VITE_SPOTIFY_CLIENT_REDIRECT_URL,
+          customScopes as string[],
+        )
+
+        const spotifySdk = new SpotifyApi(auth)
+
+        try {
+          const { authenticated } = await spotifySdk.authenticate()
+          if (authenticated) {
+            setSdk(spotifySdk)
+          }
+        } catch (e) {
+          console.error('Authentication error:', e)
+        }
+      } catch (error) {
+        console.error('Failed to initialize Spotify SDK:', error)
+      }
+    }
+
+    initSdk()
+  }, [])
+
+  return { sdk }
+}
+
+export const useCurrentUser = (sdk: SpotifyApi | null) => {
+  const [user, setUser] = useState<UserProfile | null>(null)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!sdk) {
+      return // Don't fetch if SDK is not available
+    }
+
+    const fetchUserProfile = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        if (sdk && sdk.currentUser) {
+          const userProfile: UserProfile = await sdk.currentUser.profile()
+          setUser(userProfile)
+        } else {
+          throw new Error(
+            'Spotify SDK is not initialized or currentUser is unavailable',
+          )
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error occurred'
+        setError(errorMessage)
+        console.error('Spotify Auth Error: ' + error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchUserProfile()
+  }, [sdk]) // Remove 'user' from dependency array to prevent infinite loops
+
+  return { user, loading, error }
+}

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import Dashboard from './index'
+
+// Mock the hooks
+vi.mock('../../hooks/useSpotify', () => ({
+  useSpotify: vi.fn(),
+  useCurrentUser: vi.fn(),
+}))
+
+// Mock the Box component
+vi.mock('../../components/Box', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="box">{children}</div>
+  ),
+}))
+
+import { useSpotify, useCurrentUser } from '../../hooks/useSpotify'
+
+const mockUseSpotify = useSpotify as ReturnType<typeof vi.fn>
+const mockUseCurrentUser = useCurrentUser as ReturnType<typeof vi.fn>
+
+describe('Dashboard Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('shows connecting message when SDK is not available', () => {
+    mockUseSpotify.mockReturnValue({ sdk: null })
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: false,
+      error: null,
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Connecting to Spotify...')).toBeInTheDocument()
+  })
+
+  test('shows loading message when fetching user profile', () => {
+    const mockSdk = { currentUser: { profile: vi.fn() } }
+    mockUseSpotify.mockReturnValue({ sdk: mockSdk })
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: true,
+      error: null,
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Loading your profile...')).toBeInTheDocument()
+  })
+
+  test('shows error message when there is an error', () => {
+    const mockSdk = { currentUser: { profile: vi.fn() } }
+    mockUseSpotify.mockReturnValue({ sdk: mockSdk })
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: false,
+      error: 'Failed to fetch user',
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Error loading your Spotify profile: Failed to fetch user',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test('renders user profile when data is available', () => {
+    const mockSdk = { currentUser: { profile: vi.fn() } }
+    const mockUser = {
+      display_name: 'John Doe',
+      email: 'john@example.com',
+      country: 'US',
+      followers: { total: 150 },
+      images: [{ url: 'http://example.com/profile.jpg' }],
+    }
+
+    mockUseSpotify.mockReturnValue({ sdk: mockSdk })
+    mockUseCurrentUser.mockReturnValue({
+      user: mockUser,
+      loading: false,
+      error: null,
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(
+      screen.getByText('Welcome to your Spotify dashboard!'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Your Profile')).toBeInTheDocument()
+    expect(screen.getByText('John Doe')).toBeInTheDocument()
+    expect(screen.getByText('john@example.com')).toBeInTheDocument()
+    expect(screen.getByText('US')).toBeInTheDocument()
+    expect(screen.getByText('150')).toBeInTheDocument()
+
+    const profileImage = screen.getByAltText('Profile')
+    expect(profileImage).toBeInTheDocument()
+    expect(profileImage).toHaveAttribute(
+      'src',
+      'http://example.com/profile.jpg',
+    )
+  })
+
+  test('has correct displayName', () => {
+    expect(Dashboard.displayName).toBe('Dashboard')
+  })
+})

--- a/src/pages/Dashboard/index.module.css
+++ b/src/pages/Dashboard/index.module.css
@@ -1,0 +1,6 @@
+.h1 {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+  color: #1db954; /* Spotify green */
+}

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,0 +1,86 @@
+import React, { memo } from 'react'
+
+import Box from '../../components/Box'
+import { useSpotify, useCurrentUser } from '../../hooks/useSpotify'
+
+import styles from './index.module.css'
+
+interface Props {}
+
+const Dashboard: React.FC<Props> = memo(() => {
+  const { sdk } = useSpotify()
+  const { user, loading, error } = useCurrentUser(sdk)
+
+  // Loading state while SDK is initializing
+  if (!sdk) {
+    return (
+      <Box>
+        <h1 className={styles.h1}>Dashboard</h1>
+        <p>Connecting to Spotify...</p>
+      </Box>
+    )
+  }
+
+  // Loading state while fetching user profile
+  if (loading) {
+    return (
+      <Box>
+        <h1 className={styles.h1}>Dashboard</h1>
+        <p>Loading your profile...</p>
+      </Box>
+    )
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Box>
+        <h1 className={styles.h1}>Dashboard</h1>
+        <p>Error loading your Spotify profile: {error}</p>
+      </Box>
+    )
+  }
+
+  // Success state - render user profile
+  return (
+    <>
+      <Box>
+        <h1 className={styles.h1}>Dashboard</h1>
+        <p>Welcome to your Spotify dashboard!</p>
+
+        {user && (
+          <div className="mt-4">
+            <h2 className="text-xl font-semibold mb-2">Your Profile</h2>
+            <div className="space-y-2">
+              <p>
+                <strong>Name:</strong> {user.display_name}
+              </p>
+              <p>
+                <strong>Email:</strong> {user.email}
+              </p>
+              <p>
+                <strong>Country:</strong> {user.country}
+              </p>
+              <p>
+                <strong>Followers:</strong> {user.followers?.total}
+              </p>
+              {user.images && user.images[0] && (
+                <div>
+                  <strong>Profile Picture:</strong>
+                  <img
+                    src={user.images[0].url}
+                    alt="Profile"
+                    className="w-20 h-20 rounded-full mt-2"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </Box>
+    </>
+  )
+})
+Dashboard.displayName = 'Dashboard'
+
+export default Dashboard

--- a/src/pages/Index/index.tsx
+++ b/src/pages/Index/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react'
+import { useNavigate } from 'react-router'
 
 import Box from '../../components/Box'
 import logo from '../../spotify_logo.png'
@@ -8,11 +9,23 @@ import styles from './index.module.css'
 interface Props {}
 
 const Index: React.FC<Props> = memo(() => {
+  const navigate = useNavigate()
+
+  const handleSpotifyClick = () => {
+    navigate('/dashboard')
+  }
+
   return (
     <>
       <Box>
         <h1 className={styles.h1}>{process.env.REACT_APP_TEXT}</h1>
         <img src={logo} alt="spotify_logo" className="spotify-logo" />
+        <button
+          onClick={handleSpotifyClick}
+          className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded mt-4"
+        >
+          My Spotify
+        </button>
       </Box>
     </>
   )

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router'
 
 import Layout from './components/Layout/Layout'
+import Dashboard from './pages/Dashboard'
 import Index from './pages/Index'
 import Notfound from './pages/Notfound'
 
@@ -10,6 +11,14 @@ const router = createBrowserRouter([
     element: (
       <Layout>
         <Index />
+      </Layout>
+    ),
+  },
+  {
+    path: '/dashboard',
+    element: (
+      <Layout>
+        <Dashboard />
       </Layout>
     ),
   },


### PR DESCRIPTION
Add 2 hooks, a new route, page and basic test coverage

- authenticate and authorize spotify user 
- generate a spotify sdk
- fetch spotify user profile
- render user info
